### PR TITLE
Fix typos, enable NFC, allow to set salt in hmac-extension add exclude_cred_id

### DIFF
--- a/fido2-rs/src/assertion.rs
+++ b/fido2-rs/src/assertion.rs
@@ -144,7 +144,7 @@ impl AssertRequest {
         }
     }
 
-    pub fn set_hmac_salt(&mut self, salt: &[u8; 32]) -> Result<()> {
+    pub fn set_hmac_salt(&mut self, salt: &[u8]) -> Result<()> {
         unsafe {
             check(ffi::fido_assert_set_hmac_salt(
                 self.0.ptr.as_ptr(),

--- a/fido2-rs/src/assertion.rs
+++ b/fido2-rs/src/assertion.rs
@@ -143,6 +143,18 @@ impl AssertRequest {
             })
         }
     }
+
+    pub fn set_hmac_salt(&mut self, salt: &[u8; 32]) -> Result<()> {
+        unsafe {
+            check(ffi::fido_assert_set_hmac_salt(
+                self.0.ptr.as_ptr(),
+                salt.as_ptr(),
+                salt.len()
+            ))?;
+        }
+
+        Ok(())
+    }
 }
 
 /// helper for verify an exist single assertion

--- a/fido2-rs/src/credentials.rs
+++ b/fido2-rs/src/credentials.rs
@@ -84,13 +84,13 @@ impl Credential {
 
     /// Return user name, or [None] if is not set.
     pub fn user_name(&self) -> Option<&str> {
-        let user_name = unsafe { ffi::fido_cred_rp_id(self.0.as_ptr()) };
+        let user_name = unsafe { ffi::fido_cred_user_name(self.0.as_ptr()) };
         str_or_none!(user_name)
     }
 
     /// Return user display name, or [None] if is not set.
     pub fn display_name(&self) -> Option<&str> {
-        let display_name = unsafe { ffi::fido_cred_rp_id(self.0.as_ptr()) };
+        let display_name = unsafe { ffi::fido_cred_display_name(self.0.as_ptr()) };
         str_or_none!(display_name)
     }
 
@@ -303,6 +303,15 @@ impl Credential {
         Ok(())
     }
 
+    pub fn exclude_cred_id(&mut self, id: impl AsRef<[u8]>) -> Result<()> {
+        let id = id.as_ref();
+        unsafe {
+            check(ffi::fido_cred_exclude(self.0.as_ptr(), id.as_ptr(), id.len()))?;
+        }
+
+        Ok(())
+    }
+
     /// Sets the user attributes of cred.
     ///
     /// Previously set user attributes are flushed
@@ -417,7 +426,7 @@ impl Credential {
     /// Note that not all authenticators support FIDO2 and therefore may only be able to generate fido-u2f attestation statements.
     pub fn set_attestation_format(&mut self, fmt: AttestationFormat) -> Result<()> {
         let fmt = match fmt {
-            AttestationFormat::Packed => CString::new("packet"),
+            AttestationFormat::Packed => CString::new("packed"),
             AttestationFormat::FidoU2f => CString::new("fido-u2f"),
             AttestationFormat::Tpm => CString::new("tpm"),
             AttestationFormat::None => CString::new("none"),

--- a/fido2-rs/src/device.rs
+++ b/fido2-rs/src/device.rs
@@ -254,6 +254,28 @@ impl Device {
         Ok(info)
     }
 
+    pub fn get_retry_count(&self) -> Result<i32> {
+        let mut res = 0;
+        unsafe {
+            check(ffi::fido_dev_get_retry_count(
+                self.ptr.as_ptr(),
+                &mut res as *mut i32,
+            ))?;
+        }
+        Ok(res)
+    }
+
+    pub fn get_uv_retry_count(&self) -> Result<i32> {
+        let mut res = 0;
+        unsafe {
+            check(ffi::fido_dev_get_uv_retry_count(
+                self.ptr.as_ptr(),
+                &mut res as *mut i32,
+            ))?;
+        }
+        Ok(res)
+    }
+
     /// Generates a new credential on a FIDO2 device.
     ///
     /// Ask the FIDO2 device represented by dev to generate a new credential according to the following parameters defined in cred:

--- a/libfido2-sys/build.rs
+++ b/libfido2-sys/build.rs
@@ -13,7 +13,7 @@ extern crate ureq;
 #[cfg(not(target_env = "msvc"))]
 extern crate pkg_config;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use cfg_if::cfg_if;
 use sha2::{Digest, Sha256};
 use std::env;

--- a/libfido2-sys/build.rs
+++ b/libfido2-sys/build.rs
@@ -79,6 +79,8 @@ fn main() -> Result<()> {
         } else {
             // mingw, linux, and other.
             println!("cargo:rustc-link-lib=cbor");
+            println!("cargo:rustc-link-lib=udev");
+            println!("cargo:rustc-link-lib=pcsclite");
             println!("cargo:rustc-link-lib=z");
             println!("cargo:rustc-link-lib=crypto");
         }
@@ -233,6 +235,8 @@ fn build_lib() -> Result<PathBuf> {
     .define("BUILD_MANPAGES", "off")
     .define("BUILD_EXAMPLES", "off")
     .define("BUILD_TOOLS", "off")
+    .define("NFC_LINUX", "on")
+    .define("USE_PCSC", "on")
     .build();
 
     Ok(path.join("lib"))


### PR DESCRIPTION
1. Fixed typo: `packet` -> `packed`
2. Without changes in build.rs Yubikeys over NFC are not working
3. Allow to set exclude_cred_id (use-case: if you do not want to override previously generated key for given rp/uid)
4. Set hmac salt (hmac-extension useless without this)