### PR TITLE
Feature/add wrappers for largeBlob and device management

### DIFF
--- a/fido2-rs/Cargo.toml
+++ b/fido2-rs/Cargo.toml
@@ -21,6 +21,10 @@ libc = "0.2"
 [dev-dependencies]
 anyhow = "1.0.100"
 
+[[example]]
+name = "largeblob"
+path = "examples/largeblob.rs"
+
 [features]
 default = []
 vendored = ["libfido2-sys/vendored"]

--- a/fido2-rs/Cargo.toml
+++ b/fido2-rs/Cargo.toml
@@ -16,6 +16,7 @@ libfido2-sys = { version = "0.5.0", path = "../libfido2-sys" }
 openssl = "0.10.75"
 foreign-types = "=0.3.1"
 zeroize = { version = "1.8.2", features = ["std"] }
+libc = "0.2"
 
 [dev-dependencies]
 anyhow = "1.0.100"

--- a/fido2-rs/examples/largeblob.rs
+++ b/fido2-rs/examples/largeblob.rs
@@ -1,0 +1,62 @@
+//! Example: write and read data via FIDO2 largeBlob
+//!
+//! Requires a FIDO2 device with largeBlob support (e.g. YubiKey 5).
+//! The device must have a PIN set.
+//!
+//! Usage: cargo run --example largeblob
+
+use fido2_rs::assertion::AssertRequest;
+use fido2_rs::credentials::{CoseType, Credential, Extensions, Opt};
+use fido2_rs::device::{Device, DeviceList};
+
+fn main() -> anyhow::Result<()> {
+    let pin = "0000";
+    let payload = b"Hello from fido2-rs largeBlob!";
+
+    // Open first available device
+    let devices = DeviceList::list_devices(8);
+    let dev_info = devices.into_iter().next().expect("No FIDO2 device found");
+    let dev = dev_info.open()?;
+
+    // Check max largeBlob capacity
+    let info = dev.info()?;
+    println!("maxlargeblob: {} bytes", info.max_large_blob());
+
+    // Create a resident credential with largeBlobKey extension
+    let mut cred = Credential::new();
+    cred.set_client_data([0u8; 32])?;
+    cred.set_rp("fido2-rs.example", "largeBlob example")?;
+    cred.set_user([1, 2, 3, 4], "test", Some("Test User"), None)?;
+    cred.set_cose_type(CoseType::ES256)?;
+    cred.set_rk(Opt::True)?;
+    cred.set_extension(Extensions::LARGEBLOB_KEY)?;
+
+    println!("Creating credential (touch device)...");
+    dev.make_credential(&mut cred, Some(pin))?;
+
+    let blob_key = cred.large_blob_key().to_vec();
+    println!("largeBlobKey: {} bytes", blob_key.len());
+
+    // Write data
+    println!("Writing {} bytes...", payload.len());
+    dev.largeblob_set(&blob_key, payload, pin)?;
+    println!("Write OK");
+
+    // Read data back
+    println!("Reading...");
+    let data = dev.largeblob_get(&blob_key)?;
+    println!(
+        "Read {} bytes: {:?}",
+        data.len(),
+        String::from_utf8_lossy(&data)
+    );
+
+    assert_eq!(&data, payload);
+    println!("Round-trip verified!");
+
+    // Clean up
+    dev.largeblob_remove(&blob_key, pin)?;
+    println!("Removed blob entry");
+
+    Ok(())
+}

--- a/fido2-rs/examples/largeblob.rs
+++ b/fido2-rs/examples/largeblob.rs
@@ -6,15 +6,17 @@
 //! Usage: cargo run --example largeblob
 
 use fido2_rs::credentials::{CoseType, Credential, Extensions, Opt};
-use fido2_rs::device::{Device, DeviceList};
+use fido2_rs::device::DeviceList;
 
 fn main() -> anyhow::Result<()> {
     let pin = "0000";
     let payload = b"Hello from fido2-rs largeBlob!";
 
     // Open first available device
-    let devices = DeviceList::list_devices(8);
-    let dev_info = devices.into_iter().next().expect("No FIDO2 device found");
+    // Note: devices must be kept alive (mut binding) across the .next() call,
+    // as DeviceInfo holds references into DeviceList's internal buffer.
+    let mut devices = DeviceList::list_devices(8);
+    let dev_info = devices.next().expect("No FIDO2 device found");
     let dev = dev_info.open()?;
 
     // Check max largeBlob capacity
@@ -51,8 +53,9 @@ fn main() -> anyhow::Result<()> {
 
     println!("Writing {} bytes...", payload.len());
     {
-        let devices = DeviceList::list_devices(8);
-        let dev_info = devices.into_iter().next().expect("No FIDO2 device found");
+        // Keep devices alive (mut binding) for the DeviceInfo reference.
+        let mut devices = DeviceList::list_devices(8);
+        let dev_info = devices.next().expect("No FIDO2 device found");
         let dev = dev_info.open()?;
         dev.largeblob_set(&blob_key, payload, pin)?;
         println!("Write OK");
@@ -61,8 +64,9 @@ fn main() -> anyhow::Result<()> {
 
     println!("Reading...");
     let data = {
-        let devices = DeviceList::list_devices(8);
-        let dev_info = devices.into_iter().next().expect("No FIDO2 device found");
+        // Keep devices alive (mut binding) for the DeviceInfo reference.
+        let mut devices = DeviceList::list_devices(8);
+        let dev_info = devices.next().expect("No FIDO2 device found");
         let dev = dev_info.open()?;
         let result = dev.largeblob_get(&blob_key)?;
         println!(
@@ -79,8 +83,9 @@ fn main() -> anyhow::Result<()> {
     // Clean up
     println!("Removing blob entry...");
     {
-        let devices = DeviceList::list_devices(8);
-        let dev_info = devices.into_iter().next().expect("No FIDO2 device found");
+        // Keep devices alive (mut binding) for the DeviceInfo reference.
+        let mut devices = DeviceList::list_devices(8);
+        let dev_info = devices.next().expect("No FIDO2 device found");
         let dev = dev_info.open()?;
         dev.largeblob_remove(&blob_key, pin)?;
         println!("Removed blob entry");

--- a/fido2-rs/examples/largeblob.rs
+++ b/fido2-rs/examples/largeblob.rs
@@ -5,7 +5,6 @@
 //!
 //! Usage: cargo run --example largeblob
 
-use fido2_rs::assertion::AssertRequest;
 use fido2_rs::credentials::{CoseType, Credential, Extensions, Opt};
 use fido2_rs::device::{Device, DeviceList};
 
@@ -34,29 +33,58 @@ fn main() -> anyhow::Result<()> {
     println!("Creating credential (touch device)...");
     dev.make_credential(&mut cred, Some(pin))?;
 
+    // Extract and validate the largeBlobKey
     let blob_key = cred.large_blob_key().to_vec();
+    if blob_key.is_empty() {
+        anyhow::bail!(
+            "largeBlobKey missing from credential — \
+             device may not support the LARGEBLOB_KEY extension"
+        );
+    }
     println!("largeBlobKey: {} bytes", blob_key.len());
 
-    // Write data
-    println!("Writing {} bytes...", payload.len());
-    dev.largeblob_set(&blob_key, payload, pin)?;
-    println!("Write OK");
+    // Drop the device handle to release the HID session.
+    // libfido2 devices can only maintain one active HID connection at a time.
+    // After make_credential completes, we must close and re-open before
+    // calling largeblob operations.
+    drop(dev);
 
-    // Read data back
+    println!("Writing {} bytes...", payload.len());
+    {
+        let devices = DeviceList::list_devices(8);
+        let dev_info = devices.into_iter().next().expect("No FIDO2 device found");
+        let dev = dev_info.open()?;
+        dev.largeblob_set(&blob_key, payload, pin)?;
+        println!("Write OK");
+        drop(dev);
+    }
+
     println!("Reading...");
-    let data = dev.largeblob_get(&blob_key)?;
-    println!(
-        "Read {} bytes: {:?}",
-        data.len(),
-        String::from_utf8_lossy(&data)
-    );
+    let data = {
+        let devices = DeviceList::list_devices(8);
+        let dev_info = devices.into_iter().next().expect("No FIDO2 device found");
+        let dev = dev_info.open()?;
+        let result = dev.largeblob_get(&blob_key)?;
+        println!(
+            "Read {} bytes: {:?}",
+            result.len(),
+            String::from_utf8_lossy(&result)
+        );
+        result
+    };
 
     assert_eq!(&data, payload);
     println!("Round-trip verified!");
 
     // Clean up
-    dev.largeblob_remove(&blob_key, pin)?;
-    println!("Removed blob entry");
+    println!("Removing blob entry...");
+    {
+        let devices = DeviceList::list_devices(8);
+        let dev_info = devices.into_iter().next().expect("No FIDO2 device found");
+        let dev = dev_info.open()?;
+        dev.largeblob_remove(&blob_key, pin)?;
+        println!("Removed blob entry");
+    }
 
     Ok(())
 }

--- a/fido2-rs/src/device.rs
+++ b/fido2-rs/src/device.rs
@@ -89,7 +89,8 @@ impl<'a> ExactSizeIterator for DeviceList<'a> {
 impl<'a> Drop for DeviceList<'a> {
     fn drop(&mut self) {
         unsafe {
-            ffi::fido_dev_info_free(&mut self.ptr.as_ptr(), self.found);
+            let mut raw = self.ptr.as_ptr();
+            ffi::fido_dev_info_free(&mut raw, self.found);
         }
     }
 }
@@ -591,7 +592,8 @@ impl Drop for Device {
     fn drop(&mut self) {
         unsafe {
             let _ = ffi::fido_dev_close(self.ptr.as_ptr());
-            ffi::fido_dev_free(&mut self.ptr.as_ptr());
+            let mut raw = self.ptr.as_ptr();
+            ffi::fido_dev_free(&mut raw);
         }
     }
 }

--- a/fido2-rs/src/device.rs
+++ b/fido2-rs/src/device.rs
@@ -407,6 +407,184 @@ impl Device {
 
         Ok(credman)
     }
+
+    /// Set or change the FIDO2 device PIN.
+    ///
+    /// If `old_pin` is `None`, this sets the initial PIN on a device that has no
+    /// PIN configured yet. If `old_pin` is `Some(...)`, this changes the PIN from
+    /// `old_pin` to `new_pin`.
+    ///
+    /// **Please note that `fido_dev_set_pin()` is synchronous and will block if necessary.**
+    pub fn set_pin(&self, new_pin: &str, old_pin: Option<&str>) -> Result<()> {
+        let new_pin = CString::new(new_pin)?;
+        let old_pin = old_pin.map(CString::new).transpose()?;
+        let old_pin_ptr = match &old_pin {
+            Some(p) => p.as_ptr(),
+            None => std::ptr::null(),
+        };
+
+        unsafe {
+            check(ffi::fido_dev_set_pin(
+                self.ptr.as_ptr(),
+                new_pin.as_ptr(),
+                old_pin_ptr,
+            ))?;
+        }
+
+        Ok(())
+    }
+
+    /// Perform a factory reset of the FIDO2 application on the device.
+    ///
+    /// This erases all FIDO2 credentials, the device PIN, and all largeBlob data.
+    /// Other applets (PIV, OpenPGP, etc.) are not affected.
+    ///
+    /// The CTAP2 specification requires the device to have been powered on within
+    /// approximately 10 seconds for a reset to succeed. If the device has been
+    /// connected for longer, it will return `FIDO_ERR_NOT_ALLOWED`.
+    ///
+    /// **Please note that `fido_dev_reset()` is synchronous and will block if necessary.**
+    pub fn reset(&self) -> Result<()> {
+        unsafe {
+            check(ffi::fido_dev_reset(self.ptr.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Read a largeBlob entry from the device, decrypting it with the given key.
+    ///
+    /// The `key` is a 32-byte `largeBlobKey` obtained from a credential's
+    /// `large_blob_key()` (via `make_credential` or `get_assertion` with the
+    /// `LARGEBLOB_KEY` extension).
+    ///
+    /// Returns the decrypted data, or an error if no entry matches the key.
+    ///
+    /// No PIN is required for reads.
+    ///
+    /// **Please note that `fido_dev_largeblob_get()` is synchronous and will block if necessary.**
+    pub fn largeblob_get(&self, key: &[u8]) -> Result<Vec<u8>> {
+        let mut data_ptr: *mut u8 = std::ptr::null_mut();
+        let mut data_len: usize = 0;
+
+        unsafe {
+            check(ffi::fido_dev_largeblob_get(
+                self.ptr.as_ptr(),
+                key.as_ptr(),
+                key.len(),
+                &mut data_ptr,
+                &mut data_len,
+            ))?;
+
+            if data_ptr.is_null() {
+                return Ok(Vec::new());
+            }
+
+            let data = std::slice::from_raw_parts(data_ptr, data_len).to_vec();
+            libc::free(data_ptr as *mut libc::c_void);
+
+            Ok(data)
+        }
+    }
+
+    /// Store data as a largeBlob entry on the device, encrypted with the given key.
+    ///
+    /// The `key` is a 32-byte `largeBlobKey` obtained from a credential's
+    /// `large_blob_key()`. If an entry for this key already exists, it is
+    /// overwritten.
+    ///
+    /// PIN is required for write operations.
+    ///
+    /// **Please note that `fido_dev_largeblob_set()` is synchronous and will block if necessary.**
+    pub fn largeblob_set(&self, key: &[u8], data: &[u8], pin: &str) -> Result<()> {
+        let pin = CString::new(pin)?;
+
+        unsafe {
+            check(ffi::fido_dev_largeblob_set(
+                self.ptr.as_ptr(),
+                key.as_ptr(),
+                key.len(),
+                data.as_ptr(),
+                data.len(),
+                pin.as_ptr(),
+            ))?;
+        }
+
+        Ok(())
+    }
+
+    /// Remove a largeBlob entry from the device.
+    ///
+    /// The `key` is a 32-byte `largeBlobKey` identifying the entry to remove.
+    ///
+    /// PIN is required for remove operations.
+    ///
+    /// **Please note that `fido_dev_largeblob_remove()` is synchronous and will block if necessary.**
+    pub fn largeblob_remove(&self, key: &[u8], pin: &str) -> Result<()> {
+        let pin = CString::new(pin)?;
+
+        unsafe {
+            check(ffi::fido_dev_largeblob_remove(
+                self.ptr.as_ptr(),
+                key.as_ptr(),
+                key.len(),
+                pin.as_ptr(),
+            ))?;
+        }
+
+        Ok(())
+    }
+
+    /// Read the raw serialized largeBlob CBOR array from the device.
+    ///
+    /// Returns the full CBOR-encoded byte array. An empty device returns `[0x80]`
+    /// (the CBOR encoding of an empty array).
+    ///
+    /// No PIN is required for reads.
+    ///
+    /// **Please note that `fido_dev_largeblob_get_array()` is synchronous and will block if necessary.**
+    pub fn largeblob_get_array(&self) -> Result<Vec<u8>> {
+        let mut data_ptr: *mut u8 = std::ptr::null_mut();
+        let mut data_len: usize = 0;
+
+        unsafe {
+            check(ffi::fido_dev_largeblob_get_array(
+                self.ptr.as_ptr(),
+                &mut data_ptr,
+                &mut data_len,
+            ))?;
+
+            if data_ptr.is_null() {
+                return Ok(Vec::new());
+            }
+
+            let data = std::slice::from_raw_parts(data_ptr, data_len).to_vec();
+            libc::free(data_ptr as *mut libc::c_void);
+
+            Ok(data)
+        }
+    }
+
+    /// Replace the entire largeBlob CBOR array on the device.
+    ///
+    /// Pass `&[0x80]` (empty CBOR array) to erase all entries.
+    ///
+    /// PIN is required for write operations.
+    ///
+    /// **Please note that `fido_dev_largeblob_set_array()` is synchronous and will block if necessary.**
+    pub fn largeblob_set_array(&self, data: &[u8], pin: &str) -> Result<()> {
+        let pin = CString::new(pin)?;
+
+        unsafe {
+            check(ffi::fido_dev_largeblob_set_array(
+                self.ptr.as_ptr(),
+                data.as_ptr(),
+                data.len(),
+                pin.as_ptr(),
+            ))?;
+        }
+
+        Ok(())
+    }
 }
 
 impl Drop for Device {


### PR DESCRIPTION
## Summary
Add safe Rust wrappers for 7 libfido2 functions that are exposed in `libfido2-sys` but not yet wrapped by `fido2-rs`:
- `Device::set_pin(new_pin, old_pin)` — set or change device PIN
- `Device::reset()` — factory reset FIDO2 application
- `Device::largeblob_get(key)` — read a largeBlob entry by largeBlobKey
- `Device::largeblob_set(key, data, pin)` — write a largeBlob entry
- `Device::largeblob_remove(key, pin)` — delete a largeBlob entry
- `Device::largeblob_get_array()` — read the raw CBOR array
- `Device::largeblob_set_array(data, pin)` — replace the raw CBOR array
These enable CTAP 2.1 largeBlob storage from safe Rust without dropping down to raw FFI.
## Motivation
The CTAP 2.1 largeBlob extension allows storing arbitrary encrypted data on a FIDO2 authenticator, keyed by credentials. This is useful for backup key material, configuration data, or any small payload that should live on the security key itself. Currently users of `fido2-rs` must use `libfido2-sys` directly with unsafe code to access these operations.
## Changes
- `src/device.rs`: 7 new methods on `Device` with comprehensive doc comments and proper error handling; also fixes both `Drop for Device` and `Drop for DeviceList` to pass a local mutable raw pointer to `fido_dev_free`/`fido_dev_info_free` rather than a reference to a temporary from `as_ptr()`, matching the semantic intent of the C API
- `Cargo.toml`: added explicit `libc = "0.2"` dependency (needed for `free()` on libfido2-allocated buffers; already in the transitive tree via openssl-sys and libz-sys)
- `examples/largeblob.rs`: demonstrates a complete write → read → verify → remove cycle
## Code Quality
- All methods follow existing code conventions:
  - Proper error handling with `check()` from `src/utils.rs`
  - Correct PIN parameter patterns using `CString` with proper lifetime management
  - Safe memory management with `libc::free()` for malloc'd buffers from libfido2
  - All public methods have comprehensive doc comments noting synchronous blocking behavior
- Code formatted with `cargo fmt --all`
- No clippy warnings
## Notes on the Example

The largeblob example requires two usage patterns that are worth calling out:
1. **Re-open the device between credential creation and largeblob operations.** libfido2's HID transport allows only one active connection at a time. After `make_credential()` returns, `drop()` the `Device` and re-open it before calling any `largeblob_*` method, otherwise libfido2 returns `FIDO_ERR_INTERNAL`.
2. **Keep `DeviceList` alive across `DeviceInfo` usage.** `DeviceInfo` holds `&CStr` references into `DeviceList`'s internal buffer. Use a `mut` binding and call `.next()` directly rather than `into_iter().next()`, which would drop the list at the semicolon leaving dangling references:
   ```rust
   // correct
   let mut devices = DeviceList::list_devices(8);
   let dev_info = devices.next().expect("No FIDO2 device found");

## Testing
Verified end-to-end on a YubiKey 5 with largeBlob support: the example successfully completes a full write → read → verify → remove cycle.