### PR TITLE
Fix FFI safety issues in fido2-rs wrappers

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -13,7 +13,7 @@ use anyhow::Result;
 fn main() -> Result<()> {
     let dev = Device::open("windows://hello").expect("unable open windows hello");
  
-    let mut cred = Credential::new();
+    let mut cred = Credential::new()?;
     cred.set_client_data(&[1, 2, 3, 4, 5, 6])?;
     cred.set_rp("fido_rs", "fido example")?;
     cred.set_user(&[1, 2, 3, 4, 5, 6], "alice", Some("alice"), None)?;

--- a/fido2-rs/README.MD
+++ b/fido2-rs/README.MD
@@ -16,7 +16,7 @@ use anyhow::Result;
 fn main() -> Result<()> {
     let dev = Device::open("windows://hello").expect("unable open windows hello");
 
-    let mut cred = Credential::new();
+    let mut cred = Credential::new()?;
     cred.set_client_data(&[1, 2, 3, 4, 5, 6])?;
     cred.set_rp("fido_rs", "fido example")?;
     cred.set_user(&[1, 2, 3, 4, 5, 6], "alice", Some("alice"), None)?;

--- a/fido2-rs/examples/credman.rs
+++ b/fido2-rs/examples/credman.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 const PIN: &str = "123456";
 
 fn main() -> Result<()> {
-    let dev_list = DeviceList::list_devices(16);
+    let dev_list = DeviceList::list_devices(16)?;
     for dev_info in dev_list {
         println!("device path: {}", dev_info.path.to_str()?);
         println!("manufacturer: {}", dev_info.manufacturer.to_str()?);
@@ -20,7 +20,8 @@ fn main() -> Result<()> {
         let credman = dev.credman(PIN)?;
         println!("  cred count: {}", credman.count());
 
-        for rp in credman.get_rp()? {
+        let rp_list = credman.get_rp()?;
+        for rp in rp_list.iter() {
             println!("  rp: {:?}", rp);
             let rk = credman.get_rk(rp.id)?;
 

--- a/fido2-rs/examples/device_list.rs
+++ b/fido2-rs/examples/device_list.rs
@@ -1,7 +1,7 @@
 use fido2_rs::device::DeviceList;
 
 fn main() -> anyhow::Result<()> {
-    let devices = DeviceList::list_devices(16);
+    let devices = DeviceList::list_devices(16)?;
     for dev_info in devices {
         let dev = dev_info.open()?;
 

--- a/fido2-rs/examples/largeblob.rs
+++ b/fido2-rs/examples/largeblob.rs
@@ -12,10 +12,8 @@ fn main() -> anyhow::Result<()> {
     let pin = "0000";
     let payload = b"Hello from fido2-rs largeBlob!";
 
-    // Open first available device
-    // Note: devices must be kept alive (mut binding) across the .next() call,
-    // as DeviceInfo holds references into DeviceList's internal buffer.
-    let mut devices = DeviceList::list_devices(8);
+    // Open first available device.
+    let mut devices = DeviceList::list_devices(8)?;
     let dev_info = devices.next().expect("No FIDO2 device found");
     let dev = dev_info.open()?;
 
@@ -24,7 +22,7 @@ fn main() -> anyhow::Result<()> {
     println!("maxlargeblob: {} bytes", info.max_large_blob());
 
     // Create a resident credential with largeBlobKey extension
-    let mut cred = Credential::new();
+    let mut cred = Credential::new()?;
     cred.set_client_data([0u8; 32])?;
     cred.set_rp("fido2-rs.example", "largeBlob example")?;
     cred.set_user([1, 2, 3, 4], "test", Some("Test User"), None)?;
@@ -53,8 +51,7 @@ fn main() -> anyhow::Result<()> {
 
     println!("Writing {} bytes...", payload.len());
     {
-        // Keep devices alive (mut binding) for the DeviceInfo reference.
-        let mut devices = DeviceList::list_devices(8);
+        let mut devices = DeviceList::list_devices(8)?;
         let dev_info = devices.next().expect("No FIDO2 device found");
         let dev = dev_info.open()?;
         dev.largeblob_set(&blob_key, payload, pin)?;
@@ -64,8 +61,7 @@ fn main() -> anyhow::Result<()> {
 
     println!("Reading...");
     let data = {
-        // Keep devices alive (mut binding) for the DeviceInfo reference.
-        let mut devices = DeviceList::list_devices(8);
+        let mut devices = DeviceList::list_devices(8)?;
         let dev_info = devices.next().expect("No FIDO2 device found");
         let dev = dev_info.open()?;
         let result = dev.largeblob_get(&blob_key)?;
@@ -83,8 +79,7 @@ fn main() -> anyhow::Result<()> {
     // Clean up
     println!("Removing blob entry...");
     {
-        // Keep devices alive (mut binding) for the DeviceInfo reference.
-        let mut devices = DeviceList::list_devices(8);
+        let mut devices = DeviceList::list_devices(8)?;
         let dev_info = devices.next().expect("No FIDO2 device found");
         let dev = dev_info.open()?;
         dev.largeblob_remove(&blob_key, pin)?;

--- a/fido2-rs/src/assertion.rs
+++ b/fido2-rs/src/assertion.rs
@@ -1,7 +1,7 @@
 use crate::credentials::{CoseType, Opt};
 use crate::error::{FidoError, Result};
 use crate::key::{ES256, ES384, Eddsa, Rsa};
-use crate::utils::check;
+use crate::utils::{allocation_error, check, slice_or_empty};
 use ffi::FIDO_ERR_INVALID_ARGUMENT;
 use openssl::nid::Nid;
 use openssl::pkey::{Id, PKey, Public};
@@ -134,13 +134,12 @@ impl_assertion_set!(AssertRequest, 0.ptr);
 impl AssertRequest {
     /// Return a [AssertRequest]
     #[allow(clippy::new_without_default)]
-    pub fn new() -> AssertRequest {
+    pub fn new() -> Result<AssertRequest> {
         unsafe {
             let assert = ffi::fido_assert_new();
+            let assert = NonNull::new(assert).ok_or_else(allocation_error)?;
 
-            AssertRequest(Assertions {
-                ptr: NonNull::new_unchecked(assert),
-            })
+            Ok(AssertRequest(Assertions { ptr: assert }))
         }
     }
 
@@ -165,14 +164,18 @@ impl_assertion_set!(AssertVerifier, 0.ptr);
 impl AssertVerifier {
     /// Return a [AssertVerifier] for verify.
     #[allow(clippy::new_without_default)]
-    pub fn new() -> AssertVerifier {
+    pub fn new() -> Result<AssertVerifier> {
         unsafe {
             let assert = ffi::fido_assert_new();
-            ffi::fido_assert_set_count(assert, 1);
+            let assert = NonNull::new(assert).ok_or_else(allocation_error)?;
 
-            AssertVerifier(Assertions {
-                ptr: NonNull::new_unchecked(assert),
-            })
+            if let Err(err) = check(ffi::fido_assert_set_count(assert.as_ptr(), 1)) {
+                let mut raw = assert.as_ptr();
+                ffi::fido_assert_free(&mut raw);
+                return Err(err.into());
+            }
+
+            Ok(AssertVerifier(Assertions { ptr: assert }))
         }
     }
 
@@ -261,7 +264,7 @@ impl AssertVerifier {
                     check(ffi::fido_assert_verify(
                         self.0.ptr.as_ptr(),
                         0,
-                        CoseType::EDDSA as i32,
+                        CoseType::RS256 as i32,
                         pk.as_ptr().cast(),
                     ))?;
                 }
@@ -357,7 +360,7 @@ impl Assertion<'_> {
         let len = unsafe { ffi::fido_assert_authdata_len(self.ptr.as_ptr(), self.idx) };
         let ptr = unsafe { ffi::fido_assert_authdata_ptr(self.ptr.as_ptr(), self.idx) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return client data hash.
@@ -365,7 +368,7 @@ impl Assertion<'_> {
         let len = unsafe { ffi::fido_assert_clientdata_hash_len(self.ptr.as_ptr()) };
         let ptr = unsafe { ffi::fido_assert_clientdata_hash_ptr(self.ptr.as_ptr()) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return the credBlob attribute.
@@ -373,7 +376,7 @@ impl Assertion<'_> {
         let len = unsafe { ffi::fido_assert_blob_len(self.ptr.as_ptr(), self.idx) };
         let ptr = unsafe { ffi::fido_assert_blob_ptr(self.ptr.as_ptr(), self.idx) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return the hmac-secret attribute.
@@ -385,7 +388,7 @@ impl Assertion<'_> {
         let len = unsafe { ffi::fido_assert_hmac_secret_len(self.ptr.as_ptr(), self.idx) };
         let ptr = unsafe { ffi::fido_assert_hmac_secret_ptr(self.ptr.as_ptr(), self.idx) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return largeBlobKey attribute.
@@ -393,7 +396,7 @@ impl Assertion<'_> {
         let len = unsafe { ffi::fido_assert_largeblob_key_len(self.ptr.as_ptr(), self.idx) };
         let ptr = unsafe { ffi::fido_assert_largeblob_key_ptr(self.ptr.as_ptr(), self.idx) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return user ID.
@@ -401,7 +404,7 @@ impl Assertion<'_> {
         let len = unsafe { ffi::fido_assert_user_id_len(self.ptr.as_ptr(), self.idx) };
         let ptr = unsafe { ffi::fido_assert_user_id_ptr(self.ptr.as_ptr(), self.idx) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return signature
@@ -409,7 +412,7 @@ impl Assertion<'_> {
         let len = unsafe { ffi::fido_assert_sig_len(self.ptr.as_ptr(), self.idx) };
         let ptr = unsafe { ffi::fido_assert_sig_ptr(self.ptr.as_ptr(), self.idx) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return credential ID
@@ -417,7 +420,7 @@ impl Assertion<'_> {
         let len = unsafe { ffi::fido_assert_id_len(self.ptr.as_ptr(), self.idx) };
         let ptr = unsafe { ffi::fido_assert_id_ptr(self.ptr.as_ptr(), self.idx) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return signature count.

--- a/fido2-rs/src/cbor.rs
+++ b/fido2-rs/src/cbor.rs
@@ -2,16 +2,19 @@ use std::collections::HashMap;
 use std::ffi::CStr;
 use std::ptr::NonNull;
 
+use crate::error::Result;
+use crate::utils::{allocation_error, slice_or_empty};
+
 pub struct CBORInfo {
     pub(crate) ptr: NonNull<ffi::fido_cbor_info_t>,
 }
 
 impl CBORInfo {
-    pub(crate) fn new() -> CBORInfo {
+    pub(crate) fn new() -> Result<CBORInfo> {
         unsafe {
-            CBORInfo {
-                ptr: NonNull::new_unchecked(ffi::fido_cbor_info_new()),
-            }
+            let ptr = ffi::fido_cbor_info_new();
+            let ptr = NonNull::new(ptr).ok_or_else(allocation_error)?;
+            Ok(CBORInfo { ptr })
         }
     }
 
@@ -20,7 +23,7 @@ impl CBORInfo {
             let len = ffi::fido_cbor_info_aaguid_len(self.ptr.as_ptr());
             let ptr = ffi::fido_cbor_info_aaguid_ptr(self.ptr.as_ptr());
 
-            std::slice::from_raw_parts(ptr, len)
+            slice_or_empty(ptr, len)
         }
     }
 
@@ -29,7 +32,7 @@ impl CBORInfo {
             let len = ffi::fido_cbor_info_extensions_len(self.ptr.as_ptr());
             let ptr = ffi::fido_cbor_info_extensions_ptr(self.ptr.as_ptr());
 
-            let exts = std::slice::from_raw_parts(ptr, len);
+            let exts = slice_or_empty(ptr, len);
 
             exts.iter()
                 .map(|it| CStr::from_ptr(*it))
@@ -43,7 +46,7 @@ impl CBORInfo {
             let len = ffi::fido_cbor_info_protocols_len(self.ptr.as_ptr());
             let ptr = ffi::fido_cbor_info_protocols_ptr(self.ptr.as_ptr());
 
-            std::slice::from_raw_parts(ptr, len)
+            slice_or_empty(ptr, len)
         }
     }
 
@@ -52,7 +55,7 @@ impl CBORInfo {
             let len = ffi::fido_cbor_info_transports_len(self.ptr.as_ptr());
             let ptr = ffi::fido_cbor_info_transports_ptr(self.ptr.as_ptr());
 
-            let txs = std::slice::from_raw_parts(ptr, len);
+            let txs = slice_or_empty(ptr, len);
 
             txs.iter()
                 .map(|it| CStr::from_ptr(*it))
@@ -66,7 +69,7 @@ impl CBORInfo {
             let len = ffi::fido_cbor_info_versions_len(self.ptr.as_ptr());
             let ptr = ffi::fido_cbor_info_versions_ptr(self.ptr.as_ptr());
 
-            let versions = std::slice::from_raw_parts(ptr, len);
+            let versions = slice_or_empty(ptr, len);
 
             versions
                 .iter()
@@ -82,8 +85,8 @@ impl CBORInfo {
             let names = ffi::fido_cbor_info_options_name_ptr(self.ptr.as_ptr());
             let values = ffi::fido_cbor_info_options_value_ptr(self.ptr.as_ptr());
 
-            let names = std::slice::from_raw_parts(names, len);
-            let values = std::slice::from_raw_parts(values, len);
+            let names = slice_or_empty(names, len);
+            let values = slice_or_empty(values, len);
 
             names
                 .iter()
@@ -121,8 +124,8 @@ impl CBORInfo {
             let names = ffi::fido_cbor_info_certs_name_ptr(self.ptr.as_ptr());
             let values = ffi::fido_cbor_info_certs_value_ptr(self.ptr.as_ptr());
 
-            let names = std::slice::from_raw_parts(names, len);
-            let values = std::slice::from_raw_parts(values, len);
+            let names = slice_or_empty(names, len);
+            let values = slice_or_empty(values, len);
 
             names
                 .iter()

--- a/fido2-rs/src/credentials.rs
+++ b/fido2-rs/src/credentials.rs
@@ -6,7 +6,7 @@ use bitflags::bitflags;
 use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
 
 use crate::error::Result;
-use crate::utils::check;
+use crate::utils::{allocation_error, check, slice_or_empty};
 
 /// FIDO credential
 pub struct Credential(pub(crate) NonNull<ffi::fido_cred_t>);
@@ -15,7 +15,8 @@ impl Drop for Credential {
     fn drop(&mut self) {
         unsafe {
             // `fido_cred_free` set this ptr to `NULL`
-            ffi::fido_cred_free(&mut self.0.as_ptr());
+            let mut ptr = self.0.as_ptr();
+            ffi::fido_cred_free(&mut ptr);
         }
     }
 }
@@ -116,7 +117,7 @@ impl CredentialRef {
         let len = unsafe { ffi::fido_cred_authdata_len(self.as_ptr()) };
         let ptr = unsafe { ffi::fido_cred_authdata_ptr(self.as_ptr()) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return raw authenticator data.
@@ -126,7 +127,7 @@ impl CredentialRef {
         let len = unsafe { ffi::fido_cred_authdata_raw_len(self.as_ptr()) };
         let ptr = unsafe { ffi::fido_cred_authdata_raw_ptr(self.as_ptr()) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return client data hash
@@ -136,7 +137,7 @@ impl CredentialRef {
         let len = unsafe { ffi::fido_cred_clientdata_hash_len(self.as_ptr()) };
         let ptr = unsafe { ffi::fido_cred_clientdata_hash_ptr(self.as_ptr()) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return credential ID
@@ -146,7 +147,7 @@ impl CredentialRef {
         let len = unsafe { ffi::fido_cred_id_len(self.as_ptr()) };
         let ptr = unsafe { ffi::fido_cred_id_ptr(self.as_ptr()) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return authenticator attestation GUID
@@ -156,7 +157,7 @@ impl CredentialRef {
         let len = unsafe { ffi::fido_cred_aaguid_len(self.as_ptr()) };
         let ptr = unsafe { ffi::fido_cred_aaguid_ptr(self.as_ptr()) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return "largeBlobKey".
@@ -166,7 +167,7 @@ impl CredentialRef {
         let len = unsafe { ffi::fido_cred_largeblob_key_len(self.as_ptr()) };
         let ptr = unsafe { ffi::fido_cred_largeblob_key_ptr(self.as_ptr()) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return public key.
@@ -176,7 +177,7 @@ impl CredentialRef {
         let len = unsafe { ffi::fido_cred_pubkey_len(self.as_ptr()) };
         let ptr = unsafe { ffi::fido_cred_pubkey_ptr(self.as_ptr()) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return signature.
@@ -186,7 +187,7 @@ impl CredentialRef {
         let len = unsafe { ffi::fido_cred_sig_len(self.as_ptr()) };
         let ptr = unsafe { ffi::fido_cred_sig_ptr(self.as_ptr()) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return user ID.
@@ -196,7 +197,7 @@ impl CredentialRef {
         let len = unsafe { ffi::fido_cred_user_id_len(self.as_ptr()) };
         let ptr = unsafe { ffi::fido_cred_user_id_ptr(self.as_ptr()) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return X509 certificate.
@@ -206,7 +207,7 @@ impl CredentialRef {
         let len = unsafe { ffi::fido_cred_x5c_len(self.as_ptr()) };
         let ptr = unsafe { ffi::fido_cred_x5c_ptr(self.as_ptr()) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return attestation statement.
@@ -216,7 +217,7 @@ impl CredentialRef {
         let len = unsafe { ffi::fido_cred_attstmt_len(self.as_ptr()) };
         let ptr = unsafe { ffi::fido_cred_attstmt_ptr(self.as_ptr()) };
 
-        unsafe { std::slice::from_raw_parts(ptr, len) }
+        unsafe { slice_or_empty(ptr, len) }
     }
 
     /// Return the COSE algorithm of cred.
@@ -274,11 +275,12 @@ impl CredentialRef {
 impl Credential {
     /// Create a new credential
     #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    pub fn new() -> Result<Self> {
         unsafe {
             let cred = ffi::fido_cred_new();
+            let cred = NonNull::new(cred).ok_or_else(allocation_error)?;
 
-            Credential(NonNull::new_unchecked(cred))
+            Ok(Credential(cred))
         }
     }
 

--- a/fido2-rs/src/credman.rs
+++ b/fido2-rs/src/credman.rs
@@ -10,7 +10,7 @@ use zeroize::Zeroizing;
 use crate::credentials::{Credential, CredentialRef};
 use crate::device::Device;
 use crate::error::Result;
-use crate::utils::check;
+use crate::utils::{allocation_error, check};
 
 /// FIDO2 credential management.
 pub struct CredentialManagement<'a> {
@@ -45,46 +45,53 @@ impl<'a> CredentialManagement<'a> {
     }
 
     /// Get information about relying parties with resident credentials in dev.
-    pub fn get_rp(&self) -> Result<IterRP<'a>> {
+    pub fn get_rp(&self) -> Result<CredManRP> {
         let pin_ptr = self.pin.as_ptr();
 
         unsafe {
             let p = ffi::fido_credman_rp_new();
+            let p = NonNull::new(p).ok_or_else(allocation_error)?;
 
-            check(ffi::fido_credman_get_dev_rp(
+            if let Err(err) = check(ffi::fido_credman_get_dev_rp(
                 self.dev.ptr.as_ptr(),
-                p,
+                p.as_ptr(),
                 pin_ptr,
-            ))?;
+            )) {
+                let mut raw = p.as_ptr();
+                ffi::fido_credman_rp_free(&mut raw);
+                return Err(err.into());
+            }
 
-            let total = ffi::fido_credman_rp_count(p);
-
-            Ok(IterRP {
-                idx: 0,
-                total,
-                rp: NonNull::new_unchecked(p),
+            Ok(CredManRP {
+                ptr: p,
                 _phantom: Default::default(),
             })
         }
     }
 
     /// Get resident credentials belonging to rp (relying parties) in dev.
-    pub fn get_rk<'i, I: Into<Cow<'i, CStr>>>(&self, rp: I) -> Result<CredManRK<'a>> {
+    pub fn get_rk<'i, I: Into<Cow<'i, CStr>>>(&self, rp: I) -> Result<CredManRK> {
         let rp = rp.into();
         let pin_ptr = self.pin.as_ptr();
 
         unsafe {
             let rk = ffi::fido_credman_rk_new();
-            check(ffi::fido_credman_get_dev_rk(
+            let rk = NonNull::new(rk).ok_or_else(allocation_error)?;
+
+            if let Err(err) = check(ffi::fido_credman_get_dev_rk(
                 self.dev.ptr.as_ptr(),
                 rp.as_ptr(),
-                rk,
+                rk.as_ptr(),
                 pin_ptr,
-            ))?;
+            )) {
+                let mut raw = rk.as_ptr();
+                ffi::fido_credman_rk_free(&mut raw);
+                return Err(err.into());
+            }
 
             Ok(CredManRK {
-                ptr: NonNull::new_unchecked(rk),
-                _phantom: PhantomData::default(),
+                ptr: rk,
+                _phantom: PhantomData,
             })
         }
     }
@@ -135,25 +142,26 @@ impl<'a> CredentialManagement<'a> {
 impl<'a> Drop for CredentialManagement<'a> {
     fn drop(&mut self) {
         unsafe {
-            ffi::fido_credman_metadata_free(&mut self.ptr.as_ptr());
+            let mut ptr = self.ptr.as_ptr();
+            ffi::fido_credman_metadata_free(&mut ptr);
         }
     }
 }
 
 /// Abstracts the set of resident credentials belonging to a given relying party.
-pub struct CredManRK<'a> {
+pub struct CredManRK {
     ptr: NonNull<ffi::fido_credman_rk_t>,
-    _phantom: PhantomData<&'a ()>,
+    _phantom: PhantomData<ffi::fido_credman_rk_t>,
 }
 
-impl<'a> CredManRK<'a> {
+impl CredManRK {
     /// Returns the number of resident credentials in rk
     pub fn count(&self) -> usize {
         unsafe { ffi::fido_credman_rk_count(self.ptr.as_ptr()) }
     }
 
     /// Return an iterator over the resident credentials
-    pub fn iter(&self) -> IterRK<'a> {
+    pub fn iter(&self) -> IterRK<'_> {
         let total = self.count();
 
         IterRK {
@@ -165,12 +173,24 @@ impl<'a> CredManRK<'a> {
     }
 }
 
-impl<'a> Index<usize> for CredManRK<'a> {
+impl Drop for CredManRK {
+    fn drop(&mut self) {
+        unsafe {
+            let mut ptr = self.ptr.as_ptr();
+            ffi::fido_credman_rk_free(&mut ptr);
+        }
+    }
+}
+
+impl Index<usize> for CredManRK {
     type Output = CredentialRef;
 
-    fn index(&self, index: usize) -> &'a Self::Output {
+    fn index(&self, index: usize) -> &Self::Output {
+        assert!(index < self.count(), "credential index out of bounds");
+
         unsafe {
             let ptr = ffi::fido_credman_rk(self.ptr.as_ptr(), index);
+            assert!(!ptr.is_null(), "libfido2 returned NULL for credential");
 
             // todo: how to prevent mut
             CredentialRef::from_ptr(ptr as *mut ffi::fido_cred_t)
@@ -183,7 +203,7 @@ pub struct IterRK<'a> {
     idx: usize,
     total: usize,
     rk: NonNull<ffi::fido_credman_rk_t>,
-    _phantom: PhantomData<&'a ()>,
+    _phantom: PhantomData<&'a CredManRK>,
 }
 
 impl<'a> Iterator for IterRK<'a> {
@@ -195,6 +215,7 @@ impl<'a> Iterator for IterRK<'a> {
         }
 
         let ptr = unsafe { ffi::fido_credman_rk(self.rk.as_ptr(), self.idx) };
+        assert!(!ptr.is_null(), "libfido2 returned NULL for credential");
 
         self.idx += 1;
 
@@ -217,19 +238,19 @@ pub struct RelyingParty<'a> {
 }
 
 /// Abstracts information about a relying party.
-pub struct CredManRP<'a> {
+pub struct CredManRP {
     ptr: NonNull<ffi::fido_credman_rp_t>,
-    _phantom: PhantomData<&'a ()>,
+    _phantom: PhantomData<ffi::fido_credman_rp_t>,
 }
 
-impl<'a> CredManRP<'a> {
+impl CredManRP {
     /// Returns the number of relying parties in rp
     pub fn count(&self) -> usize {
         unsafe { ffi::fido_credman_rp_count(self.ptr.as_ptr()) }
     }
 
     /// Return an iterator over the relying parties
-    pub fn iter(&self) -> IterRP<'a> {
+    pub fn iter(&self) -> IterRP<'_> {
         let total = self.count();
 
         IterRP {
@@ -241,12 +262,21 @@ impl<'a> CredManRP<'a> {
     }
 }
 
+impl Drop for CredManRP {
+    fn drop(&mut self) {
+        unsafe {
+            let mut ptr = self.ptr.as_ptr();
+            ffi::fido_credman_rp_free(&mut ptr);
+        }
+    }
+}
+
 /// Iterator over relying parties.
 pub struct IterRP<'a> {
     idx: usize,
     total: usize,
     rp: NonNull<ffi::fido_credman_rp_t>,
-    _phantom: PhantomData<&'a ()>,
+    _phantom: PhantomData<&'a CredManRP>,
 }
 
 impl<'a> Iterator for IterRP<'a> {
@@ -259,6 +289,7 @@ impl<'a> Iterator for IterRP<'a> {
 
         let id = unsafe {
             let id = ffi::fido_credman_rp_id(self.rp.as_ptr(), self.idx);
+            assert!(!id.is_null(), "libfido2 returned NULL for relying party id");
 
             CStr::from_ptr(id)
         };

--- a/fido2-rs/src/device.rs
+++ b/fido2-rs/src/device.rs
@@ -3,10 +3,10 @@ use crate::cbor::CBORInfo;
 use crate::credentials::Credential;
 use crate::credman::CredentialManagement;
 use crate::error::{Error, Result};
-use crate::utils::check;
+use crate::utils::{allocation_error, check, cstring_from_ptr_or_empty};
 use bitflags::bitflags;
 use ffi::fido_dev_t;
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 use zeroize::Zeroizing;
@@ -16,36 +16,41 @@ use zeroize::Zeroizing;
 /// contain fido devices found by the underlying operating system.
 ///
 /// user can call [DeviceList::list_devices] to start enumerate fido devices.
-pub struct DeviceList<'a> {
+pub struct DeviceList {
     ptr: NonNull<ffi::fido_dev_info_t>,
     idx: usize,
     found: usize,
-    _p: PhantomData<&'a ()>,
+    capacity: usize,
 }
 
-impl<'a> DeviceList<'a> {
+impl DeviceList {
     /// Enumerate up to `max` fido devices found by the underlying operating system.
     ///
     /// Currently only USB HID devices are supported
-    pub fn list_devices(max: usize) -> DeviceList<'a> {
+    pub fn list_devices(max: usize) -> Result<DeviceList> {
         unsafe {
             let mut found = 0;
             let ptr = ffi::fido_dev_info_new(max);
+            let ptr = NonNull::new(ptr).ok_or_else(allocation_error)?;
 
-            ffi::fido_dev_info_manifest(ptr, max, &mut found);
+            if let Err(err) = check(ffi::fido_dev_info_manifest(ptr.as_ptr(), max, &mut found)) {
+                let mut raw = ptr.as_ptr();
+                ffi::fido_dev_info_free(&mut raw, max);
+                return Err(err.into());
+            }
 
-            DeviceList {
-                ptr: NonNull::new_unchecked(ptr),
+            Ok(DeviceList {
+                ptr,
                 idx: 0,
                 found,
-                _p: PhantomData,
-            }
+                capacity: max,
+            })
         }
     }
 }
 
-impl<'a> Iterator for DeviceList<'a> {
-    type Item = DeviceInfo<'a>;
+impl Iterator for DeviceList {
+    type Item = DeviceInfo;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.idx >= self.found {
@@ -57,16 +62,16 @@ impl<'a> Iterator for DeviceList<'a> {
             let info = ffi::fido_dev_info_ptr(ptr, self.idx);
 
             let path = ffi::fido_dev_info_path(info);
-            let path = CStr::from_ptr(path);
+            let path = cstring_from_ptr_or_empty(path);
 
             let product_id = ffi::fido_dev_info_product(info);
             let vendor_id = ffi::fido_dev_info_vendor(info);
 
             let manufacturer = ffi::fido_dev_info_manufacturer_string(info);
-            let manufacturer = CStr::from_ptr(manufacturer);
+            let manufacturer = cstring_from_ptr_or_empty(manufacturer);
 
             let product = ffi::fido_dev_info_product_string(info);
-            let product = CStr::from_ptr(product);
+            let product = cstring_from_ptr_or_empty(product);
             self.idx += 1;
 
             Some(DeviceInfo {
@@ -80,39 +85,43 @@ impl<'a> Iterator for DeviceList<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for DeviceList<'a> {
+impl ExactSizeIterator for DeviceList {
     fn len(&self) -> usize {
-        self.found
+        self.found - self.idx
     }
 }
 
-impl<'a> Drop for DeviceList<'a> {
+impl Drop for DeviceList {
     fn drop(&mut self) {
         unsafe {
             let mut raw = self.ptr.as_ptr();
-            ffi::fido_dev_info_free(&mut raw, self.found);
+            ffi::fido_dev_info_free(&mut raw, self.capacity);
         }
     }
 }
 
 /// Device info obtained from [DeviceList]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DeviceInfo<'a> {
-    pub path: &'a CStr,
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DeviceInfo {
+    pub path: CString,
     pub product_id: i16,
     pub vendor_id: i16,
-    pub manufacturer: &'a CStr,
-    pub product: &'a CStr,
+    pub manufacturer: CString,
+    pub product: CString,
 }
 
-impl<'a> DeviceInfo<'a> {
+impl DeviceInfo {
     /// Open the device specified by this [DeviceInfo]
     pub fn open(&self) -> Result<Device> {
         unsafe {
             let ptr = ffi::fido_dev_new();
-            check(ffi::fido_dev_open(ptr, self.path.as_ptr()))?;
+            let ptr = NonNull::new(ptr).ok_or_else(allocation_error)?;
 
-            let ptr = NonNull::new_unchecked(ptr);
+            if let Err(err) = check(ffi::fido_dev_open(ptr.as_ptr(), self.path.as_ptr())) {
+                let mut raw = ptr.as_ptr();
+                ffi::fido_dev_free(&mut raw);
+                return Err(err.into());
+            }
 
             Ok(Device { ptr })
         }
@@ -121,15 +130,18 @@ impl<'a> DeviceInfo<'a> {
 
 /// A cancel handle to device, used to cancel a pending requests.
 ///
-/// This handle can be copy/clone.
+/// This handle can be copy/clone and cannot outlive the device it cancels.
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct DeviceCancel(NonNull<fido_dev_t>);
+pub struct DeviceCancel<'a> {
+    ptr: NonNull<fido_dev_t>,
+    _p: PhantomData<&'a Device>,
+}
 
-impl DeviceCancel {
+impl DeviceCancel<'_> {
     /// Cancel any pending requests on device.
     pub fn cancel(&self) {
         unsafe {
-            ffi::fido_dev_cancel(self.0.as_ptr());
+            ffi::fido_dev_cancel(self.ptr.as_ptr());
         }
     }
 }
@@ -149,29 +161,34 @@ impl Device {
         let path = CString::new(path.as_ref())?;
         unsafe {
             let dev = ffi::fido_dev_new();
-            assert!(!dev.is_null());
+            let dev = NonNull::new(dev).ok_or_else(allocation_error)?;
 
-            check(ffi::fido_dev_open(dev, path.as_ptr()))?;
+            if let Err(err) = check(ffi::fido_dev_open(dev.as_ptr(), path.as_ptr())) {
+                let mut raw = dev.as_ptr();
+                ffi::fido_dev_free(&mut raw);
+                return Err(err.into());
+            }
 
-            Ok(Device {
-                ptr: NonNull::new_unchecked(dev),
-            })
+            Ok(Device { ptr: dev })
         }
     }
 
     /// Get a handle of this device for cancel.
-    pub fn cancel_handle(&self) -> DeviceCancel {
-        DeviceCancel(self.ptr)
+    pub fn cancel_handle(&self) -> DeviceCancel<'_> {
+        DeviceCancel {
+            ptr: self.ptr,
+            _p: PhantomData,
+        }
     }
 
-    /// can be used to force CTAP2 communication with dev
+    /// Can be used to force CTAP1 (U2F) communication with dev.
     pub fn force_u2f(&self) {
         unsafe {
             ffi::fido_dev_force_u2f(self.ptr.as_ptr());
         }
     }
 
-    /// Can be used to force CTAP1 (U2F) communication with dev
+    /// Can be used to force CTAP2 communication with dev.
     pub fn force_fido2(&self) {
         unsafe {
             ffi::fido_dev_force_fido2(self.ptr.as_ptr());
@@ -245,7 +262,7 @@ impl Device {
 
     /// Return device info.
     pub fn info(&self) -> Result<CBORInfo> {
-        let info = CBORInfo::new();
+        let info = CBORInfo::new()?;
 
         unsafe {
             check(ffi::fido_dev_get_cbor_info(
@@ -301,7 +318,7 @@ impl Device {
     ///
     /// fn main() -> anyhow::Result<()> {
     ///     let dev = Device::open("windows://hello").expect("unable open device");
-    ///     let mut cred = Credential::new();
+    ///     let mut cred = Credential::new()?;
     ///     cred.set_client_data(&[1, 2, 3, 4, 5, 6])?;
     ///     cred.set_rp("fido_rs", "fido example")?;
     ///     cred.set_user(&[1, 2, 3, 4, 5, 6], "alice", Some("alice"), None)?;
@@ -351,7 +368,7 @@ impl Device {
     ///
     /// fn main() -> anyhow::Result<()> {
     ///     let dev = Device::open("windows://hello")?;
-    ///     let mut request = AssertRequest::new();    ///
+    ///     let mut request = AssertRequest::new()?;
     ///
     ///     request.set_rp("fido_rs")?;
     ///     request.set_client_data(&[1, 2, 3, 4, 5, 6])?;
@@ -391,20 +408,24 @@ impl Device {
         }
 
         let ptr = unsafe { ffi::fido_credman_metadata_new() };
+        let ptr = NonNull::new(ptr).ok_or_else(allocation_error)?;
 
         let pin = CString::new(pin)?;
         let pin_ptr = pin.as_ptr();
 
         unsafe {
-            check(ffi::fido_credman_get_dev_metadata(
+            if let Err(err) = check(ffi::fido_credman_get_dev_metadata(
                 self.ptr.as_ptr(),
-                ptr,
+                ptr.as_ptr(),
                 pin_ptr,
-            ))?;
+            )) {
+                let mut raw = ptr.as_ptr();
+                ffi::fido_credman_metadata_free(&mut raw);
+                return Err(err.into());
+            }
         }
 
-        let ptr = unsafe { NonNull::new_unchecked(ptr) };
-        let credman = CredentialManagement::new(ptr, &self, Zeroizing::new(pin));
+        let credman = CredentialManagement::new(ptr, self, Zeroizing::new(pin));
 
         Ok(credman)
     }

--- a/fido2-rs/src/key.rs
+++ b/fido2-rs/src/key.rs
@@ -1,4 +1,5 @@
 use crate::error::FidoError;
+use crate::utils::allocation_error;
 use openssl::ec::EcKey;
 use openssl::pkey::{PKey, Public};
 use std::ptr::NonNull;
@@ -22,9 +23,15 @@ macro_rules! impl_key {
 
                 unsafe {
                     let pk = $new();
-                    crate::utils::check($from(pk, value.as_ptr() as _))?;
+                    let pk = NonNull::new(pk).ok_or_else(allocation_error)?;
 
-                    Ok($ty(NonNull::new_unchecked(pk)))
+                    if let Err(err) = crate::utils::check($from(pk.as_ptr(), value.as_ptr() as _)) {
+                        let mut raw = pk.as_ptr();
+                        $drop(&mut raw);
+                        return Err(err);
+                    }
+
+                    Ok($ty(pk))
                 }
             }
         })*

--- a/fido2-rs/src/lib.rs
+++ b/fido2-rs/src/lib.rs
@@ -38,7 +38,7 @@
 //! ```rust,no_run
 //! use fido2_rs::device::DeviceList;
 //!
-//! let list = DeviceList::list_devices(4);
+//! let list = DeviceList::list_devices(4)?;
 //! for dev in list {
 //!     println!("{:?}", dev.path);
 //! }
@@ -54,7 +54,7 @@
 //! fn main() -> Result<()> {
 //!     let dev = Device::open("windows://hello").expect("unable open windows hello");
 //!  
-//!     let mut cred = Credential::new();
+//!     let mut cred = Credential::new()?;
 //!     cred.set_client_data(&[1, 2, 3, 4, 5, 6])?;
 //!     cred.set_rp("fido_rs", "fido example")?;
 //!     cred.set_user(&[1, 2, 3, 4, 5, 6], "alice", Some("alice"), None)?;

--- a/fido2-rs/src/utils.rs
+++ b/fido2-rs/src/utils.rs
@@ -1,9 +1,35 @@
 use crate::error::FidoError;
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
 
 pub(crate) const fn check(code: i32) -> Result<(), FidoError> {
     match code {
         0 => Ok(()),
         _ => Err(FidoError::new(code)),
+    }
+}
+
+pub(crate) const fn allocation_error() -> FidoError {
+    FidoError::new(ffi::FIDO_ERR_INTERNAL)
+}
+
+pub(crate) unsafe fn slice_or_empty<'a, T>(ptr: *const T, len: usize) -> &'a [T] {
+    if len == 0 {
+        &[]
+    } else {
+        assert!(
+            !ptr.is_null(),
+            "libfido2 returned NULL for a non-empty slice"
+        );
+        unsafe { std::slice::from_raw_parts(ptr, len) }
+    }
+}
+
+pub(crate) unsafe fn cstring_from_ptr_or_empty(ptr: *const c_char) -> CString {
+    if ptr.is_null() {
+        CString::new("").expect("empty strings cannot contain NUL bytes")
+    } else {
+        unsafe { CStr::from_ptr(ptr) }.to_owned()
     }
 }
 


### PR DESCRIPTION
- Fix RSA assertion verification to use COSE_RS256
- Make DeviceInfo own device strings to avoid dangling references
- Return Result from FFI allocation constructors and handle null pointers
- Avoid UB when libfido2 returns null pointers for empty byte slices
- Fix DeviceList freeing capacity and ExactSizeIterator length semantics
- Add lifetime binding to DeviceCancel
- Free credential-management RP/RK result handles on drop
- Add bounds/null checks for credential-management iterators
- Clean up failure-path leaks in device, credman, and key wrappers
- Update examples and docs for fallible constructors