### PR TITLE
feat!: support no-PIN credential management + add device_reset example

### DIFF
--- a/fido2-rs/Cargo.toml
+++ b/fido2-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fido2-rs"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["tyan boot <tyanboot@outlook.com>"]
 license = "MIT"
 description = "Rust bindings to Yubico fido2"

--- a/fido2-rs/examples/credman.rs
+++ b/fido2-rs/examples/credman.rs
@@ -17,7 +17,7 @@ fn main() -> Result<()> {
             continue;
         }
 
-        let credman = dev.credman(PIN)?;
+        let credman = dev.credman(Some(PIN))?;
         println!("  cred count: {}", credman.count());
 
         for rp in credman.get_rp()? {

--- a/fido2-rs/examples/device_reset.rs
+++ b/fido2-rs/examples/device_reset.rs
@@ -1,0 +1,49 @@
+//! Example: reset a FIDO2 device and verify the old PIN no longer works.
+//!
+//! **WARNING: This example DESTROYS all FIDO2 data on the device — credentials,
+//! PIN, and largeBlob entries. Other applets (PIV, OpenPGP) are not affected.**
+//!
+//! The CTAP2 spec requires the device to have been powered on within ~10
+//! seconds for a reset to succeed. If the device has been connected longer,
+//! unplug and reinsert it before running.
+//!
+//! Usage: cargo run --example device_reset
+
+use fido2_rs::device::DeviceList;
+use fido2_rs::error::Error;
+
+const PIN: &str = "1234";
+
+fn main() -> anyhow::Result<()> {
+    let mut devices = DeviceList::list_devices(8);
+    let dev_info = devices.next().expect("No FIDO2 device found");
+    let dev = dev_info.open()?;
+
+    println!("Factory reset (touch device)...");
+    dev.reset()?;
+    println!("  Reset OK");
+
+    println!("Setting initial PIN to \"{PIN}\"...");
+    dev.set_pin(PIN, None)?;
+    println!("  PIN set");
+
+    assert!(dev.has_pin(), "has_pin() should be true after set_pin");
+    println!("  has_pin() = true");
+
+    println!("Factory reset again (touch device)...");
+    dev.reset()?;
+    println!("  Reset OK — PIN and all credentials wiped");
+
+    assert!(!dev.has_pin(), "has_pin() should be false after reset");
+    println!("  has_pin() = false");
+
+    println!("Trying to change PIN using the old PIN (should fail)...");
+    match dev.set_pin("5678", Some(PIN)) {
+        Err(Error::Fido(e)) => println!("  Failed as expected: {e}"),
+        Ok(()) => panic!("set_pin with old PIN should have failed after reset"),
+        Err(e) => panic!("Unexpected error type: {e:?}"),
+    }
+
+    println!("\nAll checks passed — old PIN is invalid after reset.");
+    Ok(())
+}

--- a/fido2-rs/src/credman.rs
+++ b/fido2-rs/src/credman.rs
@@ -18,14 +18,14 @@ pub struct CredentialManagement<'a> {
 
     dev: &'a Device,
 
-    pin: Zeroizing<CString>,
+    pin: Option<Zeroizing<CString>>,
 }
 
 impl<'a> CredentialManagement<'a> {
     pub(crate) fn new(
         ptr: NonNull<ffi::fido_credman_metadata_t>,
         device: &'a Device,
-        pin: Zeroizing<CString>,
+        pin: Option<Zeroizing<CString>>,
     ) -> CredentialManagement<'a> {
         CredentialManagement {
             ptr,
@@ -46,7 +46,10 @@ impl<'a> CredentialManagement<'a> {
 
     /// Get information about relying parties with resident credentials in dev.
     pub fn get_rp(&self) -> Result<IterRP<'a>> {
-        let pin_ptr = self.pin.as_ptr();
+        let pin_ptr = match &self.pin {
+            Some(p) => p.as_ptr(),
+            None => std::ptr::null(),
+        };
 
         unsafe {
             let p = ffi::fido_credman_rp_new();
@@ -71,7 +74,10 @@ impl<'a> CredentialManagement<'a> {
     /// Get resident credentials belonging to rp (relying parties) in dev.
     pub fn get_rk<'i, I: Into<Cow<'i, CStr>>>(&self, rp: I) -> Result<CredManRK<'a>> {
         let rp = rp.into();
-        let pin_ptr = self.pin.as_ptr();
+        let pin_ptr = match &self.pin {
+            Some(p) => p.as_ptr(),
+            None => std::ptr::null(),
+        };
 
         unsafe {
             let rk = ffi::fido_credman_rk_new();
@@ -84,7 +90,7 @@ impl<'a> CredentialManagement<'a> {
 
             Ok(CredManRK {
                 ptr: NonNull::new_unchecked(rk),
-                _phantom: PhantomData::default(),
+                _phantom: PhantomData,
             })
         }
     }
@@ -96,7 +102,10 @@ impl<'a> CredentialManagement<'a> {
     /// # Arguments
     /// * `cred_id` - credential id
     pub fn delete_rk(&self, cred_id: &[u8]) -> Result<()> {
-        let pin_ptr = self.pin.as_ptr();
+        let pin_ptr = match &self.pin {
+            Some(p) => p.as_ptr(),
+            None => std::ptr::null(),
+        };
 
         unsafe {
             check(ffi::fido_credman_del_dev_rk(
@@ -118,7 +127,10 @@ impl<'a> CredentialManagement<'a> {
     ///
     /// Only a credential's user attributes (name, display name) may be updated at this time.
     pub fn set_rk(&self, cred: &Credential) -> Result<()> {
-        let pin_ptr = self.pin.as_ptr();
+        let pin_ptr = match &self.pin {
+            Some(p) => p.as_ptr(),
+            None => std::ptr::null(),
+        };
 
         unsafe {
             check(ffi::fido_credman_set_dev_rk(

--- a/fido2-rs/src/device.rs
+++ b/fido2-rs/src/device.rs
@@ -501,6 +501,16 @@ impl Device {
     ///
     /// PIN is required for write operations.
     ///
+    /// # Storage
+    ///
+    /// The largeBlob array is **shared across all credentials** and is very
+    /// small — typically 1024–4096 bytes total, with ~28 bytes of encryption
+    /// overhead per entry. Not suitable for sensitive data: the encryption key
+    /// is transmitted in the clear and the array can be read without user
+    /// verification. See the [CTAP 2.1 spec, §6.10][spec] for details.
+    ///
+    /// [spec]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorLargeBlobs
+    ///
     /// **Please note that `fido_dev_largeblob_set()` is synchronous and will block if necessary.**
     pub fn largeblob_set(&self, key: &[u8], data: &[u8], pin: &str) -> Result<()> {
         let pin = CString::new(pin)?;

--- a/fido2-rs/src/device.rs
+++ b/fido2-rs/src/device.rs
@@ -381,19 +381,25 @@ impl Device {
 
     /// Obtain a handle to the credential management interface of a FIDO2 device.
     ///
-    /// A valid pin must be provided. If the device does not support credential management,
-    /// or an error happened, error will be returned.
+    /// If the device has a PIN set, a valid PIN must be provided as `Some(pin)`.
+    /// For devices with no PIN configured, pass `None`.
+    ///
+    /// If the device does not support credential management, or an error happened,
+    /// an error will be returned.
     ///
     /// **Pin will be kept in memory and zeroized securely when the returned CredentialManagement is dropped.**
-    pub fn credman(&self, pin: &str) -> Result<CredentialManagement<'_>> {
+    pub fn credman(&self, pin: Option<&str>) -> Result<CredentialManagement<'_>> {
         if !self.supports_credman() {
             return Err(Error::Unsupported);
         }
 
         let ptr = unsafe { ffi::fido_credman_metadata_new() };
 
-        let pin = CString::new(pin)?;
-        let pin_ptr = pin.as_ptr();
+        let pin = pin.map(CString::new).transpose()?;
+        let pin_ptr = match &pin {
+            Some(pin) => pin.as_ptr(),
+            None => std::ptr::null(),
+        };
 
         unsafe {
             check(ffi::fido_credman_get_dev_metadata(
@@ -404,7 +410,7 @@ impl Device {
         }
 
         let ptr = unsafe { NonNull::new_unchecked(ptr) };
-        let credman = CredentialManagement::new(ptr, &self, Zeroizing::new(pin));
+        let credman = CredentialManagement::new(ptr, self, pin.map(Zeroizing::new));
 
         Ok(credman)
     }


### PR DESCRIPTION
## Summary

- Change `Device::credman(pin: &str)` → `Device::credman(pin: Option<&str>)` to support devices with no PIN configured (uses built-in UV instead). Forward `None` as a null pointer to all `fido_credman_get_dev_*` calls.
- Add `examples/device_reset.rs` demonstrating `set_pin` + `reset` round-trip and verifying the old PIN is invalid after reset.
- Add storage size + security caveat to `Device::largeblob_set` doc comment with link to CTAP 2.1 spec §6.10.

## Motivation

`Device::credman` previously required a non-empty PIN, blocking any flow that needs to enumerate resident credentials on a device using built-in UV (fingerprint) instead of a PIN. The CTAP 2.1 spec allows `pinUvAuthParam` to be obtained via `getPinUvAuthTokenUsingUvWithPermissions` — the `None` case maps to this path.

## Changes

- `src/device.rs`: `credman(&str)` → `credman(Option<&str>)`; storage disclaimer on `largeblob_set`
- `src/credman.rs`: `pin: Zeroizing<CString>` → `Option<Zeroizing<CString>>`; 4 `pin_ptr` sites handle `None`; `PhantomData::default()` → `PhantomData` (clippy fix)
- `examples/credman.rs`: `credman(PIN)` → `credman(Some(PIN))`
- `examples/device_reset.rs`: new example
- `Cargo.toml`: bump version 0.5.0 → 0.6.0

## Breaking change

`credman("1234")` must be updated to `credman(Some("1234"))`. The no-PIN case is `credman(None)`.

Every change has been human verified. :)